### PR TITLE
Ensure text within XML elements is properly escaped

### DIFF
--- a/lib/rss.ex
+++ b/lib/rss.ex
@@ -10,26 +10,30 @@ defmodule RSS do
     """
   end
 
-  def item(title, desc, pubDate, link, guid) do
+  def item(title, desc, pub_date, link, guid) do
     """
     <item>
-      <title>#{title}</title>
-      <description><![CDATA[#{desc}]]></description>
-      <pubDate>#{pubDate}</pubDate>
-      <link>#{link}</link>
-      <guid>#{guid}</guid>
+      #{element(:title, title)}
+      #{element(:description, desc)}
+      #{element(:pubDate, pub_date)}
+      #{element(:link, link)}
+      #{element(:guid, guid)}
     </item>
     """
   end
 
   def channel(title, link, desc, date, lang) do
     """
-      <title>#{title}</title>
-      <link>#{link}</link>
-      <description>#{desc}</description>
-      <lastBuildDate>#{date}</lastBuildDate>
-      <language>#{lang}</language>
+      #{element(:title, title)}
+      #{element(:link, link)}
+      #{element(:description, desc)}
+      #{element(:lastBuildDate, date)}
+      #{element(:language, lang)}
     """
   end
 
+  defp element(tag, text) do
+    text_chars = to_charlist(text)
+    :xmerl.export_simple_element({tag, [text_chars]}, :xmerl_xml)
+  end
 end

--- a/test/rss_test.exs
+++ b/test/rss_test.exs
@@ -2,34 +2,34 @@ defmodule RSSTest do
   use ExUnit.Case
 
   test "build an item definition" do
-    title = "Cats love lasers"
-    link = "http://mycatblog/cats-love-lasers"
+    title = "Cats love <lasers>"
+    link = "http://mycatblog/cats-love-lasers?lover=cats&lovee=lasers"
     guid = "http://mycatblog/cats-love-lasers"
-    desc = "Combining the awesomeness of cats and lasers"
+    desc = "Combining the awesomeness of cats & lasers"
     pubDate = "Mon, 12 Sep 2005 18:37:00 GMT"
 
     assert RSS.item(title, desc, pubDate, link, guid) == """
     <item>
-      <title>#{title}</title>
-      <description><![CDATA[#{desc}]]></description>
+      <title>Cats love &lt;lasers&gt;</title>
+      <description>Combining the awesomeness of cats &amp; lasers</description>
       <pubDate>#{pubDate}</pubDate>
-      <link>#{link}</link>
+      <link>http://mycatblog/cats-love-lasers?lover=cats&amp;lovee=lasers</link>
       <guid>#{guid}</guid>
     </item>
     """
   end
 
   test "build a channel definition" do
-    title = "Good Cat Blog"
-    link = "http://goodcats.bestblog.com/"
-    desc = "A blog about cats"
+    title = "Good Cat <Blog>"
+    link = "http://goodcats.bestblog.com/blog?subject=cats&bad=false"
+    desc = "A blog about cats & how good they are"
     date = "Mon, 12 Sep 2005 18:37:00 GMT"
     lang = "en-us"
 
     assert RSS.channel(title, link, desc, date, lang) == """
-      <title>#{title}</title>
-      <link>#{link}</link>
-      <description>#{desc}</description>
+      <title>Good Cat &lt;Blog&gt;</title>
+      <link>http://goodcats.bestblog.com/blog?subject=cats&amp;bad=false</link>
+      <description>A blog about cats &amp; how good they are</description>
       <lastBuildDate>#{date}</lastBuildDate>
       <language>#{lang}</language>
     """
@@ -51,14 +51,14 @@ defmodule RSSTest do
       <language>en-us</language>
     <item>
       <title>Post 2</title>
-      <description><![CDATA[The second post]]></description>
+      <description>The second post</description>
       <pubDate>Mon, 12 Sep 2005 18:37:00 GMT</pubDate>
       <link>http://test.blog/two</link>
       <guid>http://test.blog/two</guid>
     </item>
     <item>
       <title>Post 1</title>
-      <description><![CDATA[The first post]]></description>
+      <description>The first post</description>
       <pubDate>Sun, 11 Sep 2005 18:37:00 GMT</pubDate>
       <link>http://test.blog/one</link>
       <guid>http://test.blog/one</guid>

--- a/test/rss_test.exs
+++ b/test/rss_test.exs
@@ -7,8 +7,10 @@ defmodule RSSTest do
     guid = "http://mycatblog/cats-love-lasers"
     desc = "Combining the awesomeness of cats & lasers"
     pubDate = "Mon, 12 Sep 2005 18:37:00 GMT"
+    item = RSS.item(title, desc, pubDate, link, guid)
 
-    assert RSS.item(title, desc, pubDate, link, guid) == """
+    assert xml_parsing_error(item) == nil
+    assert item == """
     <item>
       <title>Cats love &lt;lasers&gt;</title>
       <description>Combining the awesomeness of cats &amp; lasers</description>
@@ -25,8 +27,10 @@ defmodule RSSTest do
     desc = "A blog about cats & how good they are"
     date = "Mon, 12 Sep 2005 18:37:00 GMT"
     lang = "en-us"
+    channel = RSS.channel(title, link, desc, date, lang)
 
-    assert RSS.channel(title, link, desc, date, lang) == """
+    assert xml_parsing_error(channel) == nil
+    assert channel == """
       <title>Good Cat &lt;Blog&gt;</title>
       <link>http://goodcats.bestblog.com/blog?subject=cats&amp;bad=false</link>
       <description>A blog about cats &amp; how good they are</description>
@@ -39,8 +43,10 @@ defmodule RSSTest do
     channel = RSS.channel("Test blog", "http://test.blog", "This is a test blog", "Mon, 12 Sep 2005 18:37:00 GMT", "en-us")
     item2 = RSS.item("Post 2", "The second post", "Mon, 12 Sep 2005 18:37:00 GMT", "http://test.blog/two", "http://test.blog/two")
     item1 = RSS.item("Post 1", "The first post", "Sun, 11 Sep 2005 18:37:00 GMT", "http://test.blog/one", "http://test.blog/one")
+    feed = RSS.feed(channel, [item2, item1])
 
-    assert RSS.feed(channel, [item2, item1]) == """
+    assert xml_parsing_error(feed) == nil
+    assert feed == """
     <?xml version="1.0" encoding="utf-8"?>
     <rss version="2.0">
     <channel>
@@ -66,5 +72,17 @@ defmodule RSSTest do
     </channel>
     </rss>
     """
+  end
+
+  defp xml_parsing_error(xml) do
+    try do
+      xml
+      |> :binary.bin_to_list
+      |> :xmerl_scan.string([quiet: true])
+
+      nil
+    catch
+      :exit, error -> error
+    end
   end
 end


### PR DESCRIPTION
I tried to subscribe to the [The Phoenix blog](http://phoenixframework.org/blog) with [Blogtrottr](https://blogtrottr.com/), but it couldn't subscribe because of an XML parsing error (see the parse error [here](http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fphoenixframework.org%2Fblog.rss)). It looks like an unescaped `&` was causing the parse error. This PR has [xmerl](http://erlang.org/doc/man/xmerl.html) handle the escaping for us.

Fixes #9

Btw, the second commit isn't strictly necessary but it might help prevent invalid XML in the future...

Thanks!